### PR TITLE
Pin the pygount dependency to 1.4.0 to avoid chardet version clash

### DIFF
--- a/module_analysis/__manifest__.py
+++ b/module_analysis/__manifest__.py
@@ -27,7 +27,7 @@
         "data/ir_cron.xml",
     ],
     "external_dependencies": {
-        "python": ["pygount"],
+        "python": ["pygount==1.4.0"],
     },
     "installable": True,
 }


### PR DESCRIPTION
Fixes https://github.com/OCA/server-tools/issues/2966